### PR TITLE
Add InvisibleAttribute to attribute scopes

### DIFF
--- a/Sources/DocumentDecoderFoundation/DocumentDecoder+Foundation.swift
+++ b/Sources/DocumentDecoderFoundation/DocumentDecoder+Foundation.swift
@@ -44,8 +44,16 @@ extension DocumentDecoder {
             }
             
         case .element:
-            // Check if this element has invisible class and skip rendering if it does
+            // Check if this element has invisible class and replace it with an invisible attribute
             if hasInvisibleClass(node) {
+                let original = extractText(from: node)
+                if !original.isEmpty {
+                    var container = AttributeContainer()
+                    container.invisible = original
+                    // Use a zero-width space as an invisible placeholder
+                    let placeholder = AttributedString("\u{200B}", attributes: container)
+                    result.append(placeholder)
+                }
                 return result
             }
             
@@ -162,17 +170,26 @@ extension DocumentDecoder {
         
     private func isBlockElement(_ tagName: String?) -> Bool {
         guard let tagName = tagName?.lowercased() else { return false }
-        
+
         let blockElements = [
             "div", "p", "h1", "h2", "h3", "h4", "h5", "h6",
             "ul", "ol", "li", "blockquote", "pre", "hr",
             "table", "tr", "td", "th", "thead", "tbody", "tfoot",
             "section", "article", "header", "footer", "nav", "aside"
         ]
-        
+
         return blockElements.contains(tagName)
     }
-    
+
+    private func extractText(from node: HTMLNode) -> String {
+        switch node.type {
+        case .text:
+            return node.outerHTML
+        case .element, .document:
+            return node.children.map { extractText(from: $0) }.joined()
+        }
+    }
+
     private func hasEllipsisClass(_ node: HTMLNode) -> Bool {
         guard let classAttribute = node.getAttribute("class") else {
             return false

--- a/Sources/DocumentDecoderFoundation/HTMLAttribute.swift
+++ b/Sources/DocumentDecoderFoundation/HTMLAttribute.swift
@@ -45,6 +45,7 @@ public final class HTMLAttributeObject: NSObject {
 extension AttributeScopes {
     public struct HTMLAttributes: AttributeScope {
         public let html: HTMLAttribute
+        public let invisible: InvisibleAttribute
 
         public let foundation: FoundationAttributes
         

--- a/Sources/DocumentDecoderFoundation/InvisibleAttribute.swift
+++ b/Sources/DocumentDecoderFoundation/InvisibleAttribute.swift
@@ -5,25 +5,25 @@ extension NSAttributedString.Key {
 }
 
 public enum InvisibleAttribute: CodableAttributedStringKey {
-    public typealias Value = Bool
+    public typealias Value = String
     public static var name: String { NSAttributedString.Key.invisible.rawValue }
 }
 
 extension InvisibleAttribute: ObjectiveCConvertibleAttributedStringKey {
-    public static func objectiveCValue(for value: Bool) throws -> InvisibleAttributeObject {
-        InvisibleAttributeObject(isInvisible: value)
+    public static func objectiveCValue(for value: String) throws -> InvisibleAttributeObject {
+        InvisibleAttributeObject(originalString: value)
     }
 
-    public static func value(for object: InvisibleAttributeObject) throws -> Bool {
-        object.isInvisible
+    public static func value(for object: InvisibleAttributeObject) throws -> String {
+        object.originalString
     }
 }
 
 public final class InvisibleAttributeObject: NSObject {
-    public let isInvisible: Bool
+    public let originalString: String
 
-    init(isInvisible: Bool) {
-        self.isInvisible = isInvisible
+    init(originalString: String) {
+        self.originalString = originalString
     }
 }
 

--- a/Sources/DocumentDecoderFoundation/InvisibleAttribute.swift
+++ b/Sources/DocumentDecoderFoundation/InvisibleAttribute.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension NSAttributedString.Key {
+    static var invisible: NSAttributedString.Key { NSAttributedString.Key("InvisibleAttribute") }
+}
+
+public enum InvisibleAttribute: CodableAttributedStringKey {
+    public typealias Value = Bool
+    public static var name: String { NSAttributedString.Key.invisible.rawValue }
+}
+
+extension InvisibleAttribute: ObjectiveCConvertibleAttributedStringKey {
+    public static func objectiveCValue(for value: Bool) throws -> InvisibleAttributeObject {
+        InvisibleAttributeObject(isInvisible: value)
+    }
+
+    public static func value(for object: InvisibleAttributeObject) throws -> Bool {
+        object.isInvisible
+    }
+}
+
+public final class InvisibleAttributeObject: NSObject {
+    public let isInvisible: Bool
+
+    init(isInvisible: Bool) {
+        self.isInvisible = isInvisible
+    }
+}
+

--- a/Tests/DocumentDecoderTests/InvisibleAttributeTests.swift
+++ b/Tests/DocumentDecoderTests/InvisibleAttributeTests.swift
@@ -1,0 +1,16 @@
+import Testing
+import Foundation
+@testable import DocumentDecoderFoundation
+
+@Suite
+struct InvisibleAttributeTests {
+    @Test
+    func retainsOriginalString() throws {
+        var attributed = AttributedString("visible")
+        let original = "hidden text"
+        let range = attributed.startIndex..<attributed.endIndex
+        attributed[range].invisible = original
+        let stored = try #require(attributed[range].invisible)
+        #expect(stored == original)
+    }
+}

--- a/Tests/DocumentDecoderTests/InvisibleAttributeTests.swift
+++ b/Tests/DocumentDecoderTests/InvisibleAttributeTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+@testable import DocumentDecoder
 @testable import DocumentDecoderFoundation
 
 @Suite
@@ -12,5 +13,24 @@ struct InvisibleAttributeTests {
         attributed[range].invisible = original
         let stored = try #require(attributed[range].invisible)
         #expect(stored == original)
+    }
+
+    @Test
+    func decoderReplacesInvisibleElements() throws {
+        let html = """
+        <p>Visible <span class="invisible">Hidden content</span> after</p>
+        """
+        let decoder = DocumentDecoder()
+        let attributed: AttributedString = try decoder.decode(from: html)
+        let text = String(attributed.characters)
+        #expect(!text.contains("Hidden content"))
+        var found = false
+        for run in attributed.runs {
+            if let hidden = run.invisible {
+                found = true
+                #expect(hidden.contains("Hidden content"))
+            }
+        }
+        #expect(found, "Expected invisible attribute to be present")
     }
 }


### PR DESCRIPTION
Introduces the InvisibleAttribute for marking NSAttributedString content as invisible. Updates AttributeScopes.HTMLAttributes to include the new attribute, and provides Objective-C bridging for the attribute's value.