### PR TITLE
Allow InvisibleAttribute to store original string

### DIFF
--- a/Sources/DocumentDecoderFoundation/InvisibleAttribute.swift
+++ b/Sources/DocumentDecoderFoundation/InvisibleAttribute.swift
@@ -5,25 +5,25 @@ extension NSAttributedString.Key {
 }
 
 public enum InvisibleAttribute: CodableAttributedStringKey {
-    public typealias Value = Bool
+    public typealias Value = String
     public static var name: String { NSAttributedString.Key.invisible.rawValue }
 }
 
 extension InvisibleAttribute: ObjectiveCConvertibleAttributedStringKey {
-    public static func objectiveCValue(for value: Bool) throws -> InvisibleAttributeObject {
-        InvisibleAttributeObject(isInvisible: value)
+    public static func objectiveCValue(for value: String) throws -> InvisibleAttributeObject {
+        InvisibleAttributeObject(originalString: value)
     }
 
-    public static func value(for object: InvisibleAttributeObject) throws -> Bool {
-        object.isInvisible
+    public static func value(for object: InvisibleAttributeObject) throws -> String {
+        object.originalString
     }
 }
 
 public final class InvisibleAttributeObject: NSObject {
-    public let isInvisible: Bool
+    public let originalString: String
 
-    init(isInvisible: Bool) {
-        self.isInvisible = isInvisible
+    init(originalString: String) {
+        self.originalString = originalString
     }
 }
 

--- a/Tests/DocumentDecoderTests/InvisibleAttributeTests.swift
+++ b/Tests/DocumentDecoderTests/InvisibleAttributeTests.swift
@@ -1,0 +1,16 @@
+import Testing
+import Foundation
+@testable import DocumentDecoderFoundation
+
+@Suite
+struct InvisibleAttributeTests {
+    @Test
+    func retainsOriginalString() throws {
+        var attributed = AttributedString("visible")
+        let original = "hidden text"
+        let range = attributed.startIndex..<attributed.endIndex
+        attributed[range].invisible = original
+        let stored = try #require(attributed[range].invisible)
+        #expect(stored == original)
+    }
+}


### PR DESCRIPTION
## Summary
- Change InvisibleAttribute value type to `String` so it can store the original text
- Add unit test ensuring InvisibleAttribute retains the original string

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_689fca9d731c832c98248fcd7102040a