### PR TITLE
Use InvisibleAttribute for invisible elements

### DIFF
--- a/Sources/DocumentDecoderFoundation/DocumentDecoder+Foundation.swift
+++ b/Sources/DocumentDecoderFoundation/DocumentDecoder+Foundation.swift
@@ -44,8 +44,16 @@ extension DocumentDecoder {
             }
             
         case .element:
-            // Check if this element has invisible class and skip rendering if it does
+            // Check if this element has invisible class and replace it with an invisible attribute
             if hasInvisibleClass(node) {
+                let original = extractText(from: node)
+                if !original.isEmpty {
+                    var container = AttributeContainer()
+                    container.invisible = original
+                    // Use a zero-width space as an invisible placeholder
+                    let placeholder = AttributedString("\u{200B}", attributes: container)
+                    result.append(placeholder)
+                }
                 return result
             }
             
@@ -162,17 +170,26 @@ extension DocumentDecoder {
         
     private func isBlockElement(_ tagName: String?) -> Bool {
         guard let tagName = tagName?.lowercased() else { return false }
-        
+
         let blockElements = [
             "div", "p", "h1", "h2", "h3", "h4", "h5", "h6",
             "ul", "ol", "li", "blockquote", "pre", "hr",
             "table", "tr", "td", "th", "thead", "tbody", "tfoot",
             "section", "article", "header", "footer", "nav", "aside"
         ]
-        
+
         return blockElements.contains(tagName)
     }
-    
+
+    private func extractText(from node: HTMLNode) -> String {
+        switch node.type {
+        case .text:
+            return node.outerHTML
+        case .element, .document:
+            return node.children.map { extractText(from: $0) }.joined()
+        }
+    }
+
     private func hasEllipsisClass(_ node: HTMLNode) -> Bool {
         guard let classAttribute = node.getAttribute("class") else {
             return false

--- a/Tests/DocumentDecoderTests/InvisibleAttributeTests.swift
+++ b/Tests/DocumentDecoderTests/InvisibleAttributeTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+@testable import DocumentDecoder
 @testable import DocumentDecoderFoundation
 
 @Suite
@@ -12,5 +13,24 @@ struct InvisibleAttributeTests {
         attributed[range].invisible = original
         let stored = try #require(attributed[range].invisible)
         #expect(stored == original)
+    }
+
+    @Test
+    func decoderReplacesInvisibleElements() throws {
+        let html = """
+        <p>Visible <span class="invisible">Hidden content</span> after</p>
+        """
+        let decoder = DocumentDecoder()
+        let attributed: AttributedString = try decoder.decode(from: html)
+        let text = String(attributed.characters)
+        #expect(!text.contains("Hidden content"))
+        var found = false
+        for run in attributed.runs {
+            if let hidden = run.invisible {
+                found = true
+                #expect(hidden.contains("Hidden content"))
+            }
+        }
+        #expect(found, "Expected invisible attribute to be present")
     }
 }


### PR DESCRIPTION
## Summary
- Replace `invisible` class elements with zero-width placeholders that carry the original text in `InvisibleAttribute`
- Add helper to extract plain text from nodes
- Add test verifying decoder attaches `InvisibleAttribute`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_689fce8a2400832cad15ca9e4e0410fc