### PR TITLE
Add EllipsisAttribute support for ellipsis-marked content

### DIFF
--- a/Sources/DocumentDecoderFoundation/DocumentDecoder+Foundation.swift
+++ b/Sources/DocumentDecoderFoundation/DocumentDecoder+Foundation.swift
@@ -90,7 +90,9 @@ extension DocumentDecoder {
                     result = AttributedString(trimmedValue)
                     // TODO: Preserve attributes more carefully
                 }
-                let ellipsis = AttributedString("…")
+                var container = AttributeContainer()
+                container.ellipsis = trimmedValue
+                let ellipsis = AttributedString("…", attributes: container)
                 result.append(ellipsis)
             }
             

--- a/Sources/DocumentDecoderFoundation/EllipsisAttribute.swift
+++ b/Sources/DocumentDecoderFoundation/EllipsisAttribute.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension NSAttributedString.Key {
+    static var ellipsis: NSAttributedString.Key { NSAttributedString.Key("EllipsisAttribute") }
+}
+
+public enum EllipsisAttribute: CodableAttributedStringKey {
+    public typealias Value = String
+    public static var name: String { NSAttributedString.Key.ellipsis.rawValue }
+}
+
+extension EllipsisAttribute: ObjectiveCConvertibleAttributedStringKey {
+    public static func objectiveCValue(for value: String) throws -> EllipsisAttributeObject {
+        EllipsisAttributeObject(originalString: value)
+    }
+
+    public static func value(for object: EllipsisAttributeObject) throws -> String {
+        object.originalString
+    }
+}
+
+public final class EllipsisAttributeObject: NSObject {
+    public let originalString: String
+
+    init(originalString: String) {
+        self.originalString = originalString
+    }
+}
+

--- a/Sources/DocumentDecoderFoundation/HTMLAttribute.swift
+++ b/Sources/DocumentDecoderFoundation/HTMLAttribute.swift
@@ -46,6 +46,7 @@ extension AttributeScopes {
     public struct HTMLAttributes: AttributeScope {
         public let html: HTMLAttribute
         public let invisible: InvisibleAttribute
+        public let ellipsis: EllipsisAttribute
 
         public let foundation: FoundationAttributes
         

--- a/Tests/DocumentDecoderTests/EllipsisAttributeTests.swift
+++ b/Tests/DocumentDecoderTests/EllipsisAttributeTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import Foundation
+@testable import DocumentDecoder
+@testable import DocumentDecoderFoundation
+
+@Suite
+struct EllipsisAttributeTests {
+    @Test
+    func retainsOriginalString() throws {
+        var attributed = AttributedString("visible…")
+        let original = "original text"
+        let ellipsisRange = attributed.index(before: attributed.endIndex)..<attributed.endIndex
+        attributed[ellipsisRange].ellipsis = original
+        let stored = try #require(attributed[ellipsisRange].ellipsis)
+        #expect(stored == original)
+    }
+
+    @Test
+    func decoderAddsEllipsisAttribute() throws {
+        let html = """
+        <p class=\"ellipsis\">This text should be truncated</p>
+        """
+        let decoder = DocumentDecoder()
+        let attributed: AttributedString = try decoder.decode(from: html)
+        let text = String(attributed.characters)
+        #expect(text.contains("This text should be truncated…"))
+        var found = false
+        for run in attributed.runs {
+            if let original = run.ellipsis {
+                found = true
+                #expect(original == "This text should be truncated")
+            }
+        }
+        #expect(found, "Expected ellipsis attribute to be present")
+    }
+}

--- a/Tests/DocumentDecoderTests/EllipsisAttributeTests.swift
+++ b/Tests/DocumentDecoderTests/EllipsisAttributeTests.swift
@@ -9,7 +9,7 @@ struct EllipsisAttributeTests {
     func retainsOriginalString() throws {
         var attributed = AttributedString("visible…")
         let original = "original text"
-        let ellipsisRange = attributed.index(before: attributed.endIndex)..<attributed.endIndex
+        let ellipsisRange = attributed.index(beforeRun: attributed.endIndex)..<attributed.endIndex
         attributed[ellipsisRange].ellipsis = original
         let stored = try #require(attributed[ellipsisRange].ellipsis)
         #expect(stored == original)


### PR DESCRIPTION
## Summary
- implement `EllipsisAttribute` for storing original text on ellipsis markers
- register ellipsis attribute in the HTML attribute scope
- attach ellipsis attribute when decoding elements with ellipsis class
- add unit tests for `EllipsisAttribute`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689ff5f03898832ca63a8d3ac2f3e885